### PR TITLE
Update Solution.hs

### DIFF
--- a/Homework06/Solution.hs
+++ b/Homework06/Solution.hs
@@ -126,9 +126,25 @@ orderList =
 deliveryCost :: Double
 deliveryCost = 8.50
 
+{- previous suggestion 
 beerCosts :: [(String, Double)] -> Double
 beerCosts =
   foldr (+) deliveryCost
     . zipWith (*) (map snd bevogBeerPrices)
     . map snd
     . filter (\name -> fst name `elem` map fst bevogBeerPrices)
+    
+-}
+
+-- my suggestions
+beerCosts :: [(String, Double)] -> Double
+beerCosts =
+  foldr (+) deliveryCost
+    . zipWith (*) (map snd bevogBeerPrices)
+    . map snd
+-- or
+
+beerCosts' :: [(String, Double)] -> Double
+beerCosts' = foldl' (+) deliveryCost . zipWith' (\(_,price) (_,qty)  -> qty * price) bevogBeerPrices
+
+

--- a/Homework06/Solution.hs
+++ b/Homework06/Solution.hs
@@ -126,25 +126,7 @@ orderList =
 deliveryCost :: Double
 deliveryCost = 8.50
 
-{- previous suggestion 
 beerCosts :: [(String, Double)] -> Double
-beerCosts =
-  foldr (+) deliveryCost
-    . zipWith (*) (map snd bevogBeerPrices)
-    . map snd
-    . filter (\name -> fst name `elem` map fst bevogBeerPrices)
-    
--}
-
--- my suggestions
-beerCosts :: [(String, Double)] -> Double
-beerCosts =
-  foldr (+) deliveryCost
-    . zipWith (*) (map snd bevogBeerPrices)
-    . map snd
--- or
-
-beerCosts' :: [(String, Double)] -> Double
-beerCosts' = foldl' (+) deliveryCost . zipWith' (\(_,price) (_,qty)  -> qty * price) bevogBeerPrices
+beerCosts = foldl' (+) deliveryCost . zipWith' (\(_, price) (_, qty)  -> price * qty) bevogBeerPrices
 
 


### PR DESCRIPTION
the use of the filter function can be avoided,  zipWith already has this built in, it will only zip a number of times equal to the length of the smaller list. This can only be done because of "Assume that the two lists have the beers in the same order."