### PR TITLE
Typo fix for greaterThan18 function

### DIFF
--- a/lessons/01-Introduction-to-haskell.ipynb
+++ b/lessons/01-Introduction-to-haskell.ipynb
@@ -500,7 +500,7 @@
    },
    "outputs": [],
    "source": [
-    "greaterThan18 3"
+    "greaterThan18 30"
    ]
   },
   {


### PR DESCRIPTION
Small fix to change input to greaterThan18 from `3` to `30`.

Thank you for the fantastic course!