### PR TITLE
fixed example to match explanation

### DIFF
--- a/lessons/01-Introduction-to-haskell.ipynb
+++ b/lessons/01-Introduction-to-haskell.ipynb
@@ -500,7 +500,7 @@
    },
    "outputs": [],
    "source": [
-    "greaterThan18 3"
+    "greaterThan18 30"
    ]
   },
   {


### PR DESCRIPTION
The explanation uses 30 as an input and the example puts 3. This just adds the zero